### PR TITLE
Show subs and moderator actions in dialog logs

### DIFF
--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -431,6 +431,7 @@ void UserInfoPopup::updateLatestMessages()
 {
     auto filteredChannel = filterMessages(this->userName_, this->channel_);
     this->ui_.latestMessages->setChannel(filteredChannel);
+    this->ui_.latestMessages->setSourceChannel(this->channel_);
 
     const bool hasMessages = filteredChannel->hasMessages();
     this->ui_.latestMessages->setVisible(hasMessages);

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -63,10 +63,19 @@ namespace {
         {
             MessagePtr message = snapshot[i];
 
+            bool isSubscription =
+                message->flags.has(MessageFlag::Subscription) &&
+                message->loginName == "" &&
+                message->messageText.split(" ").at(0).compare(
+                    userName, Qt::CaseInsensitive) == 0;
+
+            bool isModAction = message->timeoutUser.compare(
+                                   userName, Qt::CaseInsensitive) == 0;
             bool isSelectedUser =
                 message->loginName.compare(userName, Qt::CaseInsensitive) == 0;
 
-            if (isSelectedUser && !message->flags.has(MessageFlag::Whisper))
+            if ((isSubscription || isModAction || isSelectedUser) &&
+                !message->flags.has(MessageFlag::Whisper))
             {
                 channelPtr->addMessage(message);
             }

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -109,6 +109,7 @@ namespace {
 
 ChannelView::ChannelView(BaseWidget *parent)
     : BaseWidget(parent)
+    , sourceChannel_(nullptr)
     , scrollBar_(new Scrollbar(this))
 {
     this->setMouseTracking(true);
@@ -619,6 +620,21 @@ void ChannelView::setChannel(ChannelPtr channel)
             this->liveStatusChanged.invoke();  //
         }));
     }
+}
+
+ChannelPtr ChannelView::sourceChannel() const
+{
+    return this->sourceChannel_;
+}
+
+void ChannelView::setSourceChannel(ChannelPtr sourceChannel)
+{
+    this->sourceChannel_ = sourceChannel;
+}
+
+bool ChannelView::hasSourceChannel() const
+{
+    return this->sourceChannel_ != nullptr;
 }
 
 void ChannelView::messageAppended(MessagePtr &message,
@@ -1791,7 +1807,8 @@ void ChannelView::hideEvent(QHideEvent *)
 void ChannelView::showUserInfoPopup(const QString &userName)
 {
     auto *userPopup = new UserInfoPopup;
-    userPopup->setData(userName, this->channel_);
+    userPopup->setData(userName, this->hasSourceChannel() ? this->sourceChannel_
+                                                          : this->channel_);
     userPopup->setActionOnFocusLoss(BaseWindow::Delete);
     QPoint offset(int(150 * this->scale()), int(70 * this->scale()));
     userPopup->move(QCursor::pos() - offset);

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -76,6 +76,10 @@ public:
     ChannelPtr channel();
     void setChannel(ChannelPtr channel_);
 
+    ChannelPtr sourceChannel() const;
+    void setSourceChannel(ChannelPtr sourceChannel);
+    bool hasSourceChannel() const;
+
     LimitedQueueSnapshot<MessageLayoutPtr> getMessagesSnapshot();
     void queueLayout();
 
@@ -174,6 +178,7 @@ private:
     LimitedQueueSnapshot<MessageLayoutPtr> snapshot_;
 
     ChannelPtr channel_;
+    ChannelPtr sourceChannel_;
 
     Scrollbar *scrollBar_;
     EffectLabel *goToBottom_;


### PR DESCRIPTION
# Description

Subs, resubs, gifted subs, and moderation actions (i.e. timed out, banned) will now show in the `UserInfoPopup` logs.

It also preserves the original channel when opening usercards from within usercards.